### PR TITLE
Discord: Use PTB download link instead of Canary

### DIFF
--- a/README.md
+++ b/README.md
@@ -704,7 +704,7 @@ Builds - [Java on M1 Benchmarks](https://docs.google.com/spreadsheets/d/1g4U7LAI
 * [Aviary Twitter Client](https://apps.apple.com/us/app/aviary/id1522043420) - ✅ Yes, Full Native Apple Silicon Support - [🧪 Apple Silicon App Tested](https://doesitarm.com/apple-silicon-app-test/)
 * [Canary Mail](https://canarymail.io/) - ✅ Yes, Full Native Apple Silicon Support - [Article](https://setapp.sjv.io/apple-silicon-supported-apps) [View on Setapp](https://setapp.sjv.io/c/2708043/482429/5114)
 * [Cisco Webex Meetings](https://www.webex.com/downloads.html) - ✅ Yes, Full Native Apple Silicon Support - [Verification](https://github.com/ThatGuySam/doesitarm/issues/530#issue-790322821)
-* [Discord](https://discord.com/download) - ✳️ Yes, works via Rosetta 2 with native support in beta - [Canary Download](https://discord.com/api/download/canary?platform=osx) [Rosseta Verification](https://github.com/ThatGuySam/doesitarm/issues/192#issuecomment-734753133)
+* [Discord](https://discord.com/download) - ✳️ Yes, works via Rosetta 2 with native support in beta - [PTB Download](https://discord.com/api/download/ptb?platform=osx) [Rosseta Verification](https://github.com/ThatGuySam/doesitarm/issues/192#issuecomment-734753133)
 * [Facebook Messenger Desktop](https://www.messenger.com/desktop) - ✳️ Yes, works via Rosetta 2 - [Verification](https://github.com/ThatGuySam/doesitarm/issues/520)
 * [Guilded](https://www.guilded.gg/) - ✳️ Yes, works via Rosetta 2 - [Verification](https://github.com/ThatGuySam/doesitarm/issues/781#issue-1014658498)
 * [Keybase](https://keybase.io/) - ✳️ Yes, works via Rosetta 2 - [Verification](https://github.com/ThatGuySam/doesitarm/issues/143#issuecomment-1015904302)


### PR DESCRIPTION
Discord PTB has native ARM support ([already reported on site](https://doesitarm.com/app/discord/)). As PTB is generally more stable than Canary, I updated the page to include the PTB download link instead of Canary. [Information on Discord test clients](https://support.discord.com/hc/en-us/articles/360035675191-Discord-Testing-Clients)