### PR TITLE
Add Dusty

### DIFF
--- a/README.md
+++ b/README.md
@@ -847,6 +847,7 @@ Builds - [Java on M1 Benchmarks](https://docs.google.com/spreadsheets/d/1g4U7LAI
 * [DisplayBuddy](https://displaybuddy.app) - ✅ Yes, Full Native Apple Silicon Support as of v1.12 - [Release Notes](https://displaybuddy.app/public/DisplayBuddy_1.12.html)
 * [DisplayLink Manager](https://www.displaylink.com/downloads/macos) - ✅ Yes, Full Native Apple Silicon Support as of v1.3 - [Release Notes](https://gist.github.com/ThatGuySam/30e5f1d2ee4edacab6323acaa55791fc)
 * [Displays for Mac](https://www.jibapps.com/apps/displays/) - ✅ Yes, Full Native Apple Silicon Support as of v1.9.7 - [Source](https://twitter.com/jibapps/status/1338478515453386755)
+* [Dusty](https://toprak.sh/dusty/) - ✅ Yes, Native Apple Silicon Support as of v1.2.0 - [Release Notes](https://github.com/yagcioglutoprak/dusty/releases/tag/v1.2.0) [Download](https://github.com/yagcioglutoprak/dusty/releases/download/v1.2.0/Dusty-1.2.0.dmg) [Source](https://github.com/yagcioglutoprak/dusty)
 * [EasyFind](https://www.devontechnologies.com/apps/freeware) - ✅ Yes, Native Apple Silicon Support as of v5.0.1
 * [Find Any File](https://apps.tempel.org/FindAnyFile/) - ✅ Yes, Native Apple Silicon Support as of v2.3
 * [Gemini 2](https://macpaw.com/gemini) - ✳️ Yes, works via Rosetta 2 - [Official Tweet](https://twitter.com/MacPaw/status/1361651643591364613) [Article](https://setapp.sjv.io/apple-silicon-supported-apps) [View on Setapp](https://setapp.sjv.io/c/2708043/344369/5114)


### PR DESCRIPTION
## App Being Added
Dusty

#### Open Questions and Pre-Merge TODOs
- [x] Keeps list alphabetical.
- [x] Matches Standard App Line Format.
- [x] App status is clearly stated.
- [x] App status is consistent with already used verbiage.
- [x] Mentions supported App version in App Status: `v1.2.0`.

#### Verification
Dusty `v1.2.0` ships as a signed universal macOS app. Local verification on the installed release binary:

```
/Applications/Dusty.app/Contents/MacOS/Dusty: Mach-O universal binary with 2 architectures: x86_64 and arm64
Architectures in the fat file: /Applications/Dusty.app/Contents/MacOS/Dusty are: x86_64 arm64
```

The listing links the canonical landing page, the public v1.2.0 release, the DMG download, and the source repository.

#### Checks
- `git diff --check`